### PR TITLE
fix(cli): align sf.sh env defaults with sf

### DIFF
--- a/__tests__/cli-config.test.ts
+++ b/__tests__/cli-config.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { validateConfig } from "../cli/client";
+
+const ORIGINAL_ENV = {
+  SF_API_URL: process.env.SF_API_URL,
+  SF_API_KEY: process.env.SF_API_KEY,
+};
+
+afterEach(() => {
+  if (ORIGINAL_ENV.SF_API_URL === undefined) {
+    delete process.env.SF_API_URL;
+  } else {
+    process.env.SF_API_URL = ORIGINAL_ENV.SF_API_URL;
+  }
+
+  if (ORIGINAL_ENV.SF_API_KEY === undefined) {
+    delete process.env.SF_API_KEY;
+  } else {
+    process.env.SF_API_KEY = ORIGINAL_ENV.SF_API_KEY;
+  }
+});
+
+describe("validateConfig", () => {
+  test("reports missing key as error and missing URL as warning", () => {
+    delete process.env.SF_API_URL;
+    delete process.env.SF_API_KEY;
+
+    const result = validateConfig();
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("SF_API_KEY environment variable is required");
+    expect(result.warnings).toContain("SF_API_URL not set, using default: http://localhost:3000");
+  });
+
+  test("allows missing URL when key is present", () => {
+    delete process.env.SF_API_URL;
+    process.env.SF_API_KEY = "sk_test";
+
+    const result = validateConfig();
+
+    expect(result.valid).toBe(true);
+    expect(result.errors.length).toBe(0);
+    expect(result.warnings).toContain("SF_API_URL not set, using default: http://localhost:3000");
+  });
+
+  test("passes cleanly when URL and key are present", () => {
+    process.env.SF_API_URL = "http://localhost:3000";
+    process.env.SF_API_KEY = "sk_test";
+
+    const result = validateConfig();
+
+    expect(result.valid).toBe(true);
+    expect(result.errors.length).toBe(0);
+    expect(result.warnings.length).toBe(0);
+  });
+});

--- a/__tests__/sf-sh-env.test.ts
+++ b/__tests__/sf-sh-env.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect } from "bun:test";
+import { resolve } from "path";
+
+const ROOT = resolve(import.meta.dir, "..");
+
+function run(command: string, env: Record<string, string | undefined> = {}) {
+  const proc = Bun.spawnSync(["bash", "-lc", command], {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      ...env,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  return {
+    exitCode: proc.exitCode,
+    stdout: Buffer.from(proc.stdout).toString("utf8"),
+    stderr: Buffer.from(proc.stderr).toString("utf8"),
+  };
+}
+
+describe("sf.sh environment behavior", () => {
+  test("uses default API URL warning when SF_API_URL is missing", () => {
+    const result = run("unset SF_API_URL SF_API_KEY; ./cli/sf.sh sites list");
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Warning: SF_API_URL not set, using default: http://localhost:3000");
+    expect(result.stderr).toContain("Error: SF_API_KEY environment variable is required");
+  });
+
+  test("help reflects SF_API_URL default", () => {
+    const result = run("./cli/sf.sh help");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("SF_API_URL    API endpoint (default: http://localhost:3000)");
+  });
+});

--- a/cli/sf.sh
+++ b/cli/sf.sh
@@ -7,19 +7,21 @@
 # Usage: sf.sh <command> [args]
 #
 # Environment:
-#   SF_API_URL  API endpoint (required)
+#   SF_API_URL  API endpoint (optional, default: http://localhost:3000)
 #   SF_API_KEY  API key (required)
 #   SF_DOMAIN   Domain for URL display (optional, default: 498as.com)
 #
 set -e
 
 # === Configuration ===
-API_URL="${SF_API_URL:-}"
+API_URL_DEFAULT="http://localhost:3000"
+API_URL="${SF_API_URL:-$API_URL_DEFAULT}"
 API_KEY="${SF_API_KEY:-}"
 DOMAIN="${SF_DOMAIN:-498as.com}"
 
 # === Output Helpers ===
 err() { echo "Error: $1" >&2; exit 1; }
+warn() { echo "Warning: $1" >&2; }
 info() { echo "$1"; }
 
 # === JSON Parsing (no jq) ===
@@ -69,8 +71,14 @@ urlencode() {
 
 # === Validate Environment ===
 check_env() {
-    [ -z "$API_URL" ] && err "SF_API_URL environment variable is required"
-    [ -z "$API_KEY" ] && err "SF_API_KEY environment variable is required"
+    if [ -z "${SF_API_URL:-}" ]; then
+        warn "SF_API_URL not set, using default: $API_URL"
+    fi
+
+    if [ -z "$API_KEY" ]; then
+        echo "Error: SF_API_KEY environment variable is required" >&2
+        err "Set it with: export SF_API_KEY=sk_xxxxx"
+    fi
 }
 
 # === API Requests ===
@@ -599,7 +607,7 @@ Commands:
   help                             Show this help
 
 Environment:
-  SF_API_URL    API endpoint (required)
+  SF_API_URL    API endpoint (default: http://localhost:3000)
   SF_API_KEY    API key (required)
   SF_DOMAIN     Domain for URLs (default: 498as.com)
 


### PR DESCRIPTION
Closes #2.

- `sf.sh` now defaults `SF_API_URL` to `http://localhost:3000` and warns when omitted.
- `SF_API_KEY` remains mandatory with consistent guidance.
- Added regression tests for CLI config and sf.sh env behavior.

Validation:
- `bash -n cli/sf.sh`
- `bun test __tests__/cli-config.test.ts __tests__/sf-sh-env.test.ts`