### PR TITLE
feat(cli): add sf doctor diagnostics command

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ sf stats                          # Global stats
 sf stats <site>                   # Site stats
 ```
 
+### Doctor
+
+```bash
+sf doctor                         # Human-readable diagnostics
+sf doctor --json                  # Machine-readable diagnostics
+```
+
 ## For AI Agents
 
 This tool is designed to be used by AI agents.
@@ -119,9 +126,19 @@ sf upload ./new-build mysite
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `SF_API_URL` | - | API endpoint (required) |
+| `SF_API_URL` | `http://localhost:3000` | API endpoint |
 | `SF_API_KEY` | - | API key (required) |
 | `SF_DOMAIN` | 498as.com | Base domain for sites |
+
+## Troubleshooting
+
+```bash
+# Quick diagnosis (env + connectivity + auth)
+sf doctor
+
+# JSON output for scripts/agents
+sf doctor --json
+```
 
 ## API
 

--- a/__tests__/doctor.test.ts
+++ b/__tests__/doctor.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect } from "bun:test";
+import { resolve } from "path";
+
+const ROOT = resolve(import.meta.dir, "..");
+
+function run(command: string, env: Record<string, string | undefined> = {}) {
+  const proc = Bun.spawnSync(["bash", "-lc", command], {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      ...env,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  return {
+    exitCode: proc.exitCode,
+    stdout: Buffer.from(proc.stdout).toString("utf8"),
+    stderr: Buffer.from(proc.stderr).toString("utf8"),
+  };
+}
+
+describe("sf doctor", () => {
+  test("returns JSON diagnostics and non-zero when API key is missing", () => {
+    const result = run("unset SF_API_KEY SF_API_URL SF_DOMAIN; bun run cli/index.ts doctor --json");
+    expect(result.exitCode).toBe(1);
+
+    const data = JSON.parse(result.stdout);
+    expect(data.ok).toBe(false);
+    expect(data.api_url).toBe("http://localhost:3000");
+    expect(data.checks.env.api_key_present).toBe(false);
+    expect(data.checks.auth.status).toBe("fail");
+  });
+
+  test("fails connectivity and auth checks with unreachable API URL", () => {
+    const result = run("bun run cli/index.ts doctor --json", {
+      SF_API_URL: "http://127.0.0.1:9",
+      SF_API_KEY: "sk_test",
+    });
+    expect(result.exitCode).toBe(1);
+
+    const data = JSON.parse(result.stdout);
+    expect(data.ok).toBe(false);
+    expect(data.checks.health.status).toBe("fail");
+    expect(data.checks.auth.status).toBe("fail");
+  });
+});

--- a/cli/help.ts
+++ b/cli/help.ts
@@ -11,6 +11,7 @@ COMMANDS
   upload    Upload files to a site
   files     List or delete files from a site
   stats     View access statistics
+  doctor    Diagnose env, API connectivity, and auth
 
 EXAMPLES
   sf sites create docs              # Create docs.${DOMAIN}
@@ -109,4 +110,25 @@ EXAMPLES
   sf stats mysite                       # Stats for mysite
 
 TAGS: stats, analytics, monitoring
+`.trim();
+
+export const DOCTOR_HELP = `
+Diagnose configuration and connectivity
+
+USAGE
+  sf doctor [--json]
+
+CHECKS
+  env       Validate SF_API_URL/SF_API_KEY/SF_DOMAIN presence
+  health    Check API /health reachability
+  auth      Check authenticated request to /sites
+
+OPTIONS
+  --json            Output machine-readable diagnostics
+
+EXAMPLES
+  sf doctor
+  sf doctor --json
+
+TAGS: diagnostics, troubleshooting, health
 `.trim();

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-import { sites, upload, files, stats } from "./commands";
+import { sites, upload, files, stats, doctor } from "./commands";
 import { MAIN_HELP } from "./help";
 import { validateConfig } from "./client";
 
@@ -34,6 +34,7 @@ const commands: Record<string, (args: string[], opts: Options) => Promise<void>>
   upload,
   files,
   stats,
+  doctor,
 };
 
 export async function run(argv: string[]) {
@@ -51,21 +52,24 @@ export async function run(argv: string[]) {
     process.exit(1);
   }
 
-  // Validate configuration before running commands
-  const config = validateConfig();
-  
-  // Show warnings (but don't block)
-  for (const warning of config.warnings) {
-    console.error(`Warning: ${warning}`);
-  }
-  
-  // Exit on errors
-  if (!config.valid) {
-    console.error("");
-    for (const error of config.errors) {
-      console.error(`Error: ${error}`);
+  // Doctor performs its own diagnostics and should run even with missing env.
+  if (command !== "doctor") {
+    // Validate configuration before running commands
+    const config = validateConfig();
+    
+    // Show warnings (but don't block)
+    for (const warning of config.warnings) {
+      console.error(`Warning: ${warning}`);
     }
-    process.exit(1);
+    
+    // Exit on errors
+    if (!config.valid) {
+      console.error("");
+      for (const error of config.errors) {
+        console.error(`Error: ${error}`);
+      }
+      process.exit(1);
+    }
   }
 
   try {


### PR DESCRIPTION
Closes #3.

- Adds `sf doctor` with human and `--json` output.
- Checks env presence, `/health` reachability, and authenticated `/sites` request.
- Returns non-zero exit code when diagnostics fail.
- Adds tests and README troubleshooting examples.

Validation:
- `bun test __tests__/doctor.test.ts`
- `bun run cli/index.ts --help`
- `bun run cli/index.ts doctor --json` (expects non-zero without key)