### PR TITLE
feat(ops): add env bootstrap and smoke scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,24 @@ export SF_API_URL=http://localhost:3000
 export SF_API_KEY=sk_xxxxx
 ```
 
+### Bootstrap + Smoke Test
+
+```bash
+# Generate exports from key + defaults
+eval "$(scripts/bootstrap-env.sh --api-key 'sk_xxxxx' --emit-exports)"
+
+# Validate health + authenticated CLI path
+scripts/smoke-cli.sh
+```
+
+Alternative (write snippet file with restricted permissions):
+
+```bash
+scripts/bootstrap-env.sh --api-key 'sk_xxxxx' --write-file ~/.config/kleo/static-files.env
+source ~/.config/kleo/static-files.env
+scripts/smoke-cli.sh
+```
+
 ## Usage
 
 ### Sites
@@ -180,6 +198,8 @@ bun run dev          # Start server with watch
 bun run build        # Build binaries
 bun run create-key   # Generate API key
 bun run sync-caddy   # Regenerate Caddy config
+scripts/bootstrap-env.sh --help
+scripts/smoke-cli.sh --help
 ```
 
 ## License

--- a/scripts/bootstrap-env.sh
+++ b/scripts/bootstrap-env.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+ENV_FILE="${REPO_ROOT}/.env"
+PORT_DEFAULT="3000"
+DOMAIN_DEFAULT="498as.com"
+
+API_KEY="${SF_API_KEY:-}"
+API_URL="${SF_API_URL:-}"
+DOMAIN="${SF_DOMAIN:-}"
+WRITE_FILE=""
+EMIT_EXPORTS="false"
+
+usage() {
+  cat <<'EOF'
+bootstrap-env.sh - Prepare SF_* environment variables safely
+
+Usage:
+  scripts/bootstrap-env.sh [options]
+
+Options:
+  --api-key <key>       API key (if omitted, uses SF_API_KEY or prompts interactively)
+  --api-url <url>       API URL (default from .env SF_PORT or http://localhost:3000)
+  --domain <domain>     Domain (default from .env SF_DOMAIN or 498as.com)
+  --emit-exports        Print export commands to stdout
+  --write-file <path>   Write shell exports to a file (chmod 600)
+  -h, --help            Show this help
+
+Examples:
+  scripts/bootstrap-env.sh --api-key sk_xxxxx --emit-exports
+  scripts/bootstrap-env.sh --api-key sk_xxxxx --write-file ~/.config/kleo/static-files.env
+EOF
+}
+
+mask_key() {
+  local key="$1"
+  local len=${#key}
+  if [ "$len" -le 8 ]; then
+    echo "********"
+    return
+  fi
+  echo "${key:0:4}...${key: -4}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --api-key) API_KEY="${2:-}"; shift 2 ;;
+    --api-url) API_URL="${2:-}"; shift 2 ;;
+    --domain) DOMAIN="${2:-}"; shift 2 ;;
+    --emit-exports) EMIT_EXPORTS="true"; shift ;;
+    --write-file) WRITE_FILE="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Error: Unknown option '$1'" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [ -f "$ENV_FILE" ]; then
+  if [ -z "$DOMAIN" ]; then
+    env_domain="$(grep -E '^SF_DOMAIN=' "$ENV_FILE" | head -1 | cut -d'=' -f2- | tr -d '"' || true)"
+    [ -n "$env_domain" ] && DOMAIN="$env_domain"
+  fi
+  if [ -z "$API_URL" ]; then
+    env_port="$(grep -E '^SF_PORT=' "$ENV_FILE" | head -1 | cut -d'=' -f2- | tr -d '"' || true)"
+    if [ -n "$env_port" ]; then
+      API_URL="http://localhost:${env_port}"
+    fi
+  fi
+fi
+
+[ -n "$DOMAIN" ] || DOMAIN="$DOMAIN_DEFAULT"
+[ -n "$API_URL" ] || API_URL="http://localhost:${PORT_DEFAULT}"
+
+if [ -z "$API_KEY" ]; then
+  if [ -t 0 ]; then
+    read -r -s -p "Enter SF_API_KEY: " API_KEY
+    echo ""
+  else
+    echo "Error: SF_API_KEY is required (use --api-key or set SF_API_KEY)." >&2
+    exit 1
+  fi
+fi
+
+if [ -z "$API_KEY" ]; then
+  echo "Error: SF_API_KEY cannot be empty." >&2
+  exit 1
+fi
+
+if [ -n "$WRITE_FILE" ]; then
+  umask 077
+  cat > "$WRITE_FILE" <<EOF
+export SF_API_URL='${API_URL}'
+export SF_API_KEY='${API_KEY}'
+export SF_DOMAIN='${DOMAIN}'
+EOF
+  chmod 600 "$WRITE_FILE"
+  echo "Wrote environment snippet to ${WRITE_FILE} (permissions: 600)."
+fi
+
+if [ "$EMIT_EXPORTS" = "true" ]; then
+  cat <<EOF
+export SF_API_URL='${API_URL}'
+export SF_API_KEY='${API_KEY}'
+export SF_DOMAIN='${DOMAIN}'
+EOF
+  exit 0
+fi
+
+echo "Environment prepared:"
+echo "  SF_API_URL=${API_URL}"
+echo "  SF_API_KEY=$(mask_key "$API_KEY")"
+echo "  SF_DOMAIN=${DOMAIN}"
+echo ""
+echo "Next steps:"
+echo "  1) eval \"\$(scripts/bootstrap-env.sh --api-key '<key>' --emit-exports)\""
+echo "  2) scripts/smoke-cli.sh"

--- a/scripts/bootstrap-env.sh
+++ b/scripts/bootstrap-env.sh
@@ -89,6 +89,8 @@ if [ -z "$API_KEY" ]; then
 fi
 
 if [ -n "$WRITE_FILE" ]; then
+  write_dir="$(dirname "$WRITE_FILE")"
+  mkdir -p "$write_dir"
   umask 077
   cat > "$WRITE_FILE" <<EOF
 export SF_API_URL='${API_URL}'

--- a/scripts/smoke-cli.sh
+++ b/scripts/smoke-cli.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "$REPO_ROOT"
+
+API_URL="${SF_API_URL:-http://localhost:3000}"
+API_KEY="${SF_API_KEY:-}"
+
+usage() {
+  cat <<'EOF'
+smoke-cli.sh - Quick health + auth smoke checks for Static Files CLI
+
+Usage:
+  scripts/smoke-cli.sh [--api-url <url>] [--api-key <key>]
+
+Environment:
+  SF_API_URL   API endpoint (default: http://localhost:3000)
+  SF_API_KEY   API key (required)
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --api-url) API_URL="${2:-}"; shift 2 ;;
+    --api-key) API_KEY="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Error: Unknown option '$1'" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [ -z "$API_KEY" ]; then
+  echo "Error: SF_API_KEY is required (set env or pass --api-key)." >&2
+  exit 1
+fi
+
+if command -v sf >/dev/null 2>&1; then
+  SF_CMD=(sf)
+else
+  SF_CMD=(bun run cli/index.ts)
+fi
+
+echo "[smoke] API URL: ${API_URL}"
+echo "[smoke] Step 1/2: health check"
+if curl -fsS "${API_URL}/health" >/tmp/sf-smoke-health.json 2>/tmp/sf-smoke-health.err; then
+  echo "[smoke] OK: /health reachable"
+else
+  echo "[smoke] FAIL: /health unreachable"
+  sed -n '1,3p' /tmp/sf-smoke-health.err || true
+  exit 1
+fi
+
+echo "[smoke] Step 2/2: authenticated sf sites list"
+set +e
+SF_API_URL="${API_URL}" SF_API_KEY="${API_KEY}" "${SF_CMD[@]}" sites list --json >/tmp/sf-smoke-sites.out 2>/tmp/sf-smoke-sites.err
+cmd_exit=$?
+set -e
+
+if [ "$cmd_exit" -eq 0 ]; then
+  echo "[smoke] OK: authenticated CLI request succeeded"
+  echo "[smoke] PASS"
+  exit 0
+fi
+
+stderr_sample="$(sed -n '1,5p' /tmp/sf-smoke-sites.err || true)"
+if echo "$stderr_sample" | grep -qiE "auth|invalid api key|401"; then
+  echo "[smoke] FAIL: authentication rejected (check SF_API_KEY)"
+elif echo "$stderr_sample" | grep -qiE "connect|refused|timed out|network"; then
+  echo "[smoke] FAIL: connectivity error (check SF_API_URL/API service)"
+else
+  echo "[smoke] FAIL: CLI request failed"
+fi
+
+sed -n '1,8p' /tmp/sf-smoke-sites.err || true
+exit 1


### PR DESCRIPTION
Closes #5.

- Adds `scripts/bootstrap-env.sh` for safe SF_* env bootstrap.
- Adds `scripts/smoke-cli.sh` for health + authenticated CLI smoke checks.
- Documents both scripts in README quick-start/development sections.

Validation:
- `bash -n scripts/bootstrap-env.sh scripts/smoke-cli.sh`
- `./scripts/bootstrap-env.sh --help`
- `./scripts/smoke-cli.sh --help`
- `./scripts/smoke-cli.sh --api-key sk_invalid` (expected auth failure classification)