### PR TITLE
docs(static-files): add preflight and runtime-mode runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ export SF_API_URL=http://localhost:3000
 export SF_API_KEY=sk_xxxxx
 ```
 
+## Troubleshooting
+
+```bash
+# Diagnose env + health + auth
+sf doctor
+
+# Manual health check
+curl -i "$SF_API_URL/health"
+```
+
+If you are using the AI skill package, follow the preflight and runtime-mode guide in [`static-files/SKILL.md`](./static-files/SKILL.md).
+
 ## Usage
 
 ### Sites

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ source ~/.config/kleo/static-files.env
 scripts/smoke-cli.sh
 ```
 
+If you are using the AI skill package, follow the preflight and runtime-mode guide in [`static-files/SKILL.md`](./static-files/SKILL.md).
+
 ## Usage
 
 ### Sites

--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ sf stats                          # Global stats
 sf stats <site>                   # Site stats
 ```
 
+### Doctor
+
+```bash
+sf doctor                         # Human-readable diagnostics
+sf doctor --json                  # Machine-readable diagnostics
+```
+
 ## For AI Agents
 
 This tool is designed to be used by AI agents.
@@ -119,9 +126,19 @@ sf upload ./new-build mysite
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `SF_API_URL` | - | API endpoint (required) |
+| `SF_API_URL` | `http://localhost:3000` | API endpoint |
 | `SF_API_KEY` | - | API key (required) |
 | `SF_DOMAIN` | 498as.com | Base domain for sites |
+
+## Troubleshooting
+
+```bash
+# Quick diagnosis (env + connectivity + auth)
+sf doctor
+
+# JSON output for scripts/agents
+sf doctor --json
+```
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,24 @@ export SF_API_URL=http://localhost:3000
 export SF_API_KEY=sk_xxxxx
 ```
 
+### Bootstrap + Smoke Test
+
+```bash
+# Generate exports from key + defaults
+eval "$(scripts/bootstrap-env.sh --api-key 'sk_xxxxx' --emit-exports)"
+
+# Validate health + authenticated CLI path
+scripts/smoke-cli.sh
+```
+
+Alternative (write snippet file with restricted permissions):
+
+```bash
+scripts/bootstrap-env.sh --api-key 'sk_xxxxx' --write-file ~/.config/kleo/static-files.env
+source ~/.config/kleo/static-files.env
+scripts/smoke-cli.sh
+```
+
 ## Usage
 
 ### Sites
@@ -180,6 +198,8 @@ bun run dev          # Start server with watch
 bun run build        # Build binaries
 bun run create-key   # Generate API key
 bun run sync-caddy   # Regenerate Caddy config
+scripts/bootstrap-env.sh --help
+scripts/smoke-cli.sh --help
 ```
 
 ## License

--- a/__tests__/cli-config.test.ts
+++ b/__tests__/cli-config.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { validateConfig } from "../cli/client";
+
+const ORIGINAL_ENV = {
+  SF_API_URL: process.env.SF_API_URL,
+  SF_API_KEY: process.env.SF_API_KEY,
+};
+
+afterEach(() => {
+  if (ORIGINAL_ENV.SF_API_URL === undefined) {
+    delete process.env.SF_API_URL;
+  } else {
+    process.env.SF_API_URL = ORIGINAL_ENV.SF_API_URL;
+  }
+
+  if (ORIGINAL_ENV.SF_API_KEY === undefined) {
+    delete process.env.SF_API_KEY;
+  } else {
+    process.env.SF_API_KEY = ORIGINAL_ENV.SF_API_KEY;
+  }
+});
+
+describe("validateConfig", () => {
+  test("reports missing key as error and missing URL as warning", () => {
+    delete process.env.SF_API_URL;
+    delete process.env.SF_API_KEY;
+
+    const result = validateConfig();
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("SF_API_KEY environment variable is required");
+    expect(result.warnings).toContain("SF_API_URL not set, using default: http://localhost:3000");
+  });
+
+  test("allows missing URL when key is present", () => {
+    delete process.env.SF_API_URL;
+    process.env.SF_API_KEY = "sk_test";
+
+    const result = validateConfig();
+
+    expect(result.valid).toBe(true);
+    expect(result.errors.length).toBe(0);
+    expect(result.warnings).toContain("SF_API_URL not set, using default: http://localhost:3000");
+  });
+
+  test("passes cleanly when URL and key are present", () => {
+    process.env.SF_API_URL = "http://localhost:3000";
+    process.env.SF_API_KEY = "sk_test";
+
+    const result = validateConfig();
+
+    expect(result.valid).toBe(true);
+    expect(result.errors.length).toBe(0);
+    expect(result.warnings.length).toBe(0);
+  });
+});

--- a/__tests__/doctor.test.ts
+++ b/__tests__/doctor.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect } from "bun:test";
+import { resolve } from "path";
+
+const ROOT = resolve(import.meta.dir, "..");
+
+function run(command: string, env: Record<string, string | undefined> = {}) {
+  const proc = Bun.spawnSync(["bash", "-lc", command], {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      ...env,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  return {
+    exitCode: proc.exitCode,
+    stdout: Buffer.from(proc.stdout).toString("utf8"),
+    stderr: Buffer.from(proc.stderr).toString("utf8"),
+  };
+}
+
+describe("sf doctor", () => {
+  test("returns JSON diagnostics and non-zero when API key is missing", () => {
+    const result = run("unset SF_API_KEY SF_API_URL SF_DOMAIN; bun run cli/index.ts doctor --json");
+    expect(result.exitCode).toBe(1);
+
+    const data = JSON.parse(result.stdout);
+    expect(data.ok).toBe(false);
+    expect(data.api_url).toBe("http://localhost:3000");
+    expect(data.checks.env.api_key_present).toBe(false);
+    expect(data.checks.auth.status).toBe("fail");
+  });
+
+  test("fails connectivity and auth checks with unreachable API URL", () => {
+    const result = run("bun run cli/index.ts doctor --json", {
+      SF_API_URL: "http://127.0.0.1:9",
+      SF_API_KEY: "sk_test",
+    });
+    expect(result.exitCode).toBe(1);
+
+    const data = JSON.parse(result.stdout);
+    expect(data.ok).toBe(false);
+    expect(data.checks.health.status).toBe("fail");
+    expect(data.checks.auth.status).toBe("fail");
+  });
+});

--- a/__tests__/sf-sh-env.test.ts
+++ b/__tests__/sf-sh-env.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect } from "bun:test";
+import { resolve } from "path";
+
+const ROOT = resolve(import.meta.dir, "..");
+
+function run(command: string, env: Record<string, string | undefined> = {}) {
+  const proc = Bun.spawnSync(["bash", "-lc", command], {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      ...env,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  return {
+    exitCode: proc.exitCode,
+    stdout: Buffer.from(proc.stdout).toString("utf8"),
+    stderr: Buffer.from(proc.stderr).toString("utf8"),
+  };
+}
+
+describe("sf.sh environment behavior", () => {
+  test("uses default API URL warning when SF_API_URL is missing", () => {
+    const result = run("unset SF_API_URL SF_API_KEY; ./cli/sf.sh sites list");
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Warning: SF_API_URL not set, using default: http://localhost:3000");
+    expect(result.stderr).toContain("Error: SF_API_KEY environment variable is required");
+  });
+
+  test("help reflects SF_API_URL default", () => {
+    const result = run("./cli/sf.sh help");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("SF_API_URL    API endpoint (default: http://localhost:3000)");
+  });
+});

--- a/cli/help.ts
+++ b/cli/help.ts
@@ -11,6 +11,7 @@ COMMANDS
   upload    Upload files to a site
   files     List or delete files from a site
   stats     View access statistics
+  doctor    Diagnose env, API connectivity, and auth
 
 EXAMPLES
   sf sites create docs              # Create docs.${DOMAIN}
@@ -109,4 +110,25 @@ EXAMPLES
   sf stats mysite                       # Stats for mysite
 
 TAGS: stats, analytics, monitoring
+`.trim();
+
+export const DOCTOR_HELP = `
+Diagnose configuration and connectivity
+
+USAGE
+  sf doctor [--json]
+
+CHECKS
+  env       Validate SF_API_URL/SF_API_KEY/SF_DOMAIN presence
+  health    Check API /health reachability
+  auth      Check authenticated request to /sites
+
+OPTIONS
+  --json            Output machine-readable diagnostics
+
+EXAMPLES
+  sf doctor
+  sf doctor --json
+
+TAGS: diagnostics, troubleshooting, health
 `.trim();

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-import { sites, upload, files, stats } from "./commands";
+import { sites, upload, files, stats, doctor } from "./commands";
 import { MAIN_HELP } from "./help";
 import { validateConfig } from "./client";
 
@@ -34,6 +34,7 @@ const commands: Record<string, (args: string[], opts: Options) => Promise<void>>
   upload,
   files,
   stats,
+  doctor,
 };
 
 export async function run(argv: string[]) {
@@ -51,21 +52,24 @@ export async function run(argv: string[]) {
     process.exit(1);
   }
 
-  // Validate configuration before running commands
-  const config = validateConfig();
-  
-  // Show warnings (but don't block)
-  for (const warning of config.warnings) {
-    console.error(`Warning: ${warning}`);
-  }
-  
-  // Exit on errors
-  if (!config.valid) {
-    console.error("");
-    for (const error of config.errors) {
-      console.error(`Error: ${error}`);
+  // Doctor performs its own diagnostics and should run even with missing env.
+  if (command !== "doctor") {
+    // Validate configuration before running commands
+    const config = validateConfig();
+    
+    // Show warnings (but don't block)
+    for (const warning of config.warnings) {
+      console.error(`Warning: ${warning}`);
     }
-    process.exit(1);
+    
+    // Exit on errors
+    if (!config.valid) {
+      console.error("");
+      for (const error of config.errors) {
+        console.error(`Error: ${error}`);
+      }
+      process.exit(1);
+    }
   }
 
   try {

--- a/cli/sf.sh
+++ b/cli/sf.sh
@@ -7,19 +7,21 @@
 # Usage: sf.sh <command> [args]
 #
 # Environment:
-#   SF_API_URL  API endpoint (required)
+#   SF_API_URL  API endpoint (optional, default: http://localhost:3000)
 #   SF_API_KEY  API key (required)
 #   SF_DOMAIN   Domain for URL display (optional, default: 498as.com)
 #
 set -e
 
 # === Configuration ===
-API_URL="${SF_API_URL:-}"
+API_URL_DEFAULT="http://localhost:3000"
+API_URL="${SF_API_URL:-$API_URL_DEFAULT}"
 API_KEY="${SF_API_KEY:-}"
 DOMAIN="${SF_DOMAIN:-498as.com}"
 
 # === Output Helpers ===
 err() { echo "Error: $1" >&2; exit 1; }
+warn() { echo "Warning: $1" >&2; }
 info() { echo "$1"; }
 
 # === JSON Parsing (no jq) ===
@@ -69,8 +71,14 @@ urlencode() {
 
 # === Validate Environment ===
 check_env() {
-    [ -z "$API_URL" ] && err "SF_API_URL environment variable is required"
-    [ -z "$API_KEY" ] && err "SF_API_KEY environment variable is required"
+    if [ -z "${SF_API_URL:-}" ]; then
+        warn "SF_API_URL not set, using default: $API_URL"
+    fi
+
+    if [ -z "$API_KEY" ]; then
+        echo "Error: SF_API_KEY environment variable is required" >&2
+        err "Set it with: export SF_API_KEY=sk_xxxxx"
+    fi
 }
 
 # === API Requests ===
@@ -599,7 +607,7 @@ Commands:
   help                             Show this help
 
 Environment:
-  SF_API_URL    API endpoint (required)
+  SF_API_URL    API endpoint (default: http://localhost:3000)
   SF_API_KEY    API key (required)
   SF_DOMAIN     Domain for URLs (default: 498as.com)
 

--- a/scripts/bootstrap-env.sh
+++ b/scripts/bootstrap-env.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+ENV_FILE="${REPO_ROOT}/.env"
+PORT_DEFAULT="3000"
+DOMAIN_DEFAULT="498as.com"
+
+API_KEY="${SF_API_KEY:-}"
+API_URL="${SF_API_URL:-}"
+DOMAIN="${SF_DOMAIN:-}"
+WRITE_FILE=""
+EMIT_EXPORTS="false"
+
+usage() {
+  cat <<'EOF'
+bootstrap-env.sh - Prepare SF_* environment variables safely
+
+Usage:
+  scripts/bootstrap-env.sh [options]
+
+Options:
+  --api-key <key>       API key (if omitted, uses SF_API_KEY or prompts interactively)
+  --api-url <url>       API URL (default from .env SF_PORT or http://localhost:3000)
+  --domain <domain>     Domain (default from .env SF_DOMAIN or 498as.com)
+  --emit-exports        Print export commands to stdout
+  --write-file <path>   Write shell exports to a file (chmod 600)
+  -h, --help            Show this help
+
+Examples:
+  scripts/bootstrap-env.sh --api-key sk_xxxxx --emit-exports
+  scripts/bootstrap-env.sh --api-key sk_xxxxx --write-file ~/.config/kleo/static-files.env
+EOF
+}
+
+mask_key() {
+  local key="$1"
+  local len=${#key}
+  if [ "$len" -le 8 ]; then
+    echo "********"
+    return
+  fi
+  echo "${key:0:4}...${key: -4}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --api-key) API_KEY="${2:-}"; shift 2 ;;
+    --api-url) API_URL="${2:-}"; shift 2 ;;
+    --domain) DOMAIN="${2:-}"; shift 2 ;;
+    --emit-exports) EMIT_EXPORTS="true"; shift ;;
+    --write-file) WRITE_FILE="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Error: Unknown option '$1'" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [ -f "$ENV_FILE" ]; then
+  if [ -z "$DOMAIN" ]; then
+    env_domain="$(grep -E '^SF_DOMAIN=' "$ENV_FILE" | head -1 | cut -d'=' -f2- | tr -d '"' || true)"
+    [ -n "$env_domain" ] && DOMAIN="$env_domain"
+  fi
+  if [ -z "$API_URL" ]; then
+    env_port="$(grep -E '^SF_PORT=' "$ENV_FILE" | head -1 | cut -d'=' -f2- | tr -d '"' || true)"
+    if [ -n "$env_port" ]; then
+      API_URL="http://localhost:${env_port}"
+    fi
+  fi
+fi
+
+[ -n "$DOMAIN" ] || DOMAIN="$DOMAIN_DEFAULT"
+[ -n "$API_URL" ] || API_URL="http://localhost:${PORT_DEFAULT}"
+
+if [ -z "$API_KEY" ]; then
+  if [ -t 0 ]; then
+    read -r -s -p "Enter SF_API_KEY: " API_KEY
+    echo ""
+  else
+    echo "Error: SF_API_KEY is required (use --api-key or set SF_API_KEY)." >&2
+    exit 1
+  fi
+fi
+
+if [ -z "$API_KEY" ]; then
+  echo "Error: SF_API_KEY cannot be empty." >&2
+  exit 1
+fi
+
+if [ -n "$WRITE_FILE" ]; then
+  umask 077
+  cat > "$WRITE_FILE" <<EOF
+export SF_API_URL='${API_URL}'
+export SF_API_KEY='${API_KEY}'
+export SF_DOMAIN='${DOMAIN}'
+EOF
+  chmod 600 "$WRITE_FILE"
+  echo "Wrote environment snippet to ${WRITE_FILE} (permissions: 600)."
+fi
+
+if [ "$EMIT_EXPORTS" = "true" ]; then
+  cat <<EOF
+export SF_API_URL='${API_URL}'
+export SF_API_KEY='${API_KEY}'
+export SF_DOMAIN='${DOMAIN}'
+EOF
+  exit 0
+fi
+
+echo "Environment prepared:"
+echo "  SF_API_URL=${API_URL}"
+echo "  SF_API_KEY=$(mask_key "$API_KEY")"
+echo "  SF_DOMAIN=${DOMAIN}"
+echo ""
+echo "Next steps:"
+echo "  1) eval \"\$(scripts/bootstrap-env.sh --api-key '<key>' --emit-exports)\""
+echo "  2) scripts/smoke-cli.sh"

--- a/scripts/bootstrap-env.sh
+++ b/scripts/bootstrap-env.sh
@@ -89,6 +89,8 @@ if [ -z "$API_KEY" ]; then
 fi
 
 if [ -n "$WRITE_FILE" ]; then
+  write_dir="$(dirname "$WRITE_FILE")"
+  mkdir -p "$write_dir"
   umask 077
   cat > "$WRITE_FILE" <<EOF
 export SF_API_URL='${API_URL}'

--- a/scripts/smoke-cli.sh
+++ b/scripts/smoke-cli.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "$REPO_ROOT"
+
+API_URL="${SF_API_URL:-http://localhost:3000}"
+API_KEY="${SF_API_KEY:-}"
+
+usage() {
+  cat <<'EOF'
+smoke-cli.sh - Quick health + auth smoke checks for Static Files CLI
+
+Usage:
+  scripts/smoke-cli.sh [--api-url <url>] [--api-key <key>]
+
+Environment:
+  SF_API_URL   API endpoint (default: http://localhost:3000)
+  SF_API_KEY   API key (required)
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --api-url) API_URL="${2:-}"; shift 2 ;;
+    --api-key) API_KEY="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Error: Unknown option '$1'" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [ -z "$API_KEY" ]; then
+  echo "Error: SF_API_KEY is required (set env or pass --api-key)." >&2
+  exit 1
+fi
+
+if command -v sf >/dev/null 2>&1; then
+  SF_CMD=(sf)
+else
+  SF_CMD=(bun run cli/index.ts)
+fi
+
+echo "[smoke] API URL: ${API_URL}"
+echo "[smoke] Step 1/2: health check"
+if curl -fsS "${API_URL}/health" >/tmp/sf-smoke-health.json 2>/tmp/sf-smoke-health.err; then
+  echo "[smoke] OK: /health reachable"
+else
+  echo "[smoke] FAIL: /health unreachable"
+  sed -n '1,3p' /tmp/sf-smoke-health.err || true
+  exit 1
+fi
+
+echo "[smoke] Step 2/2: authenticated sf sites list"
+set +e
+SF_API_URL="${API_URL}" SF_API_KEY="${API_KEY}" "${SF_CMD[@]}" sites list --json >/tmp/sf-smoke-sites.out 2>/tmp/sf-smoke-sites.err
+cmd_exit=$?
+set -e
+
+if [ "$cmd_exit" -eq 0 ]; then
+  echo "[smoke] OK: authenticated CLI request succeeded"
+  echo "[smoke] PASS"
+  exit 0
+fi
+
+stderr_sample="$(sed -n '1,5p' /tmp/sf-smoke-sites.err || true)"
+if echo "$stderr_sample" | grep -qiE "auth|invalid api key|401"; then
+  echo "[smoke] FAIL: authentication rejected (check SF_API_KEY)"
+elif echo "$stderr_sample" | grep -qiE "connect|refused|timed out|network"; then
+  echo "[smoke] FAIL: connectivity error (check SF_API_URL/API service)"
+else
+  echo "[smoke] FAIL: CLI request failed"
+fi
+
+sed -n '1,8p' /tmp/sf-smoke-sites.err || true
+exit 1

--- a/static-files/SKILL.md
+++ b/static-files/SKILL.md
@@ -20,21 +20,24 @@ Run this before any `sf ...` command:
 
 ```bash
 # 1) Required env
-echo "$SF_API_URL"
+API_URL="${SF_API_URL:-http://localhost:3000}"
+echo "$API_URL"
 echo "$SF_API_KEY"
 
 # 2) API health
-curl -i "$SF_API_URL/health"
+curl -i "$API_URL/health"
 
-# 3) Doctor (recommended)
-sf doctor
+# 3) Doctor (if available in your sf version)
+if sf help 2>/dev/null | grep -q "doctor"; then
+  sf doctor
+fi
 ```
 
 Expected:
-- `SF_API_URL` is set (or defaults to `http://localhost:3000`)
+- API URL resolves to `http://localhost:3000` unless `SF_API_URL` is set
 - `SF_API_KEY` is set
 - `/health` returns `200`
-- `sf doctor` shows `health` and `auth` checks as PASS
+- If available, `sf doctor` shows `health` and `auth` checks as PASS
 
 If preflight fails, fix runtime/config first; do not proceed with uploads/site changes.
 

--- a/static-files/references/install.md
+++ b/static-files/references/install.md
@@ -121,18 +121,39 @@ For each subdomain to work, configure a wildcard DNS record:
 ## Verification
 
 ```bash
-# Check service
-systemctl status kleo-static-files
-
-# Check API
-curl http://localhost:3000/health
-
-# Test site creation
+# Configure CLI env
 export SF_API_URL=http://localhost:3000
 export SF_API_KEY=sk_your_key
+
+# Run diagnostics first
+sf doctor
+
+# Health check
+curl -i "$SF_API_URL/health"
+
+# Test site creation
 sf sites create test
 curl -I https://test.yourdomain.com
 ```
+
+## Runtime Modes
+
+### Systemd Host
+
+```bash
+sudo /opt/kleo-static-files/install.sh --status
+systemctl status kleo-static-files
+```
+
+### No-Systemd Runtime (container/CI/session)
+
+```bash
+cd /opt/kleo-static-files
+set -a && source .env && set +a
+bun run server/index.ts
+```
+
+Use this mode when DBus/systemd is not available. Keep the process supervised by your runtime.
 
 ## Uninstall
 


### PR DESCRIPTION
Closes #4.

- Adds mandatory preflight checks to `static-files/SKILL.md`.
- Adds explicit systemd vs no-systemd runtime branches.
- Aligns troubleshooting commands around `sf doctor` + health checks.
- Updates installation reference and README links for canonical flow.

Validation:
- Reviewed docs consistency across `static-files/SKILL.md`, `references/install.md`, and `README.md`.